### PR TITLE
fix(security): add server-side input validation for image uploads

### DIFF
--- a/app/api/analyze/route.ts
+++ b/app/api/analyze/route.ts
@@ -11,6 +11,29 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: 'Missing image or mimeType' }, { status: 400 })
     }
 
+    // Validate that image is a non-empty string
+    if (typeof image !== 'string' || image.length === 0) {
+      return NextResponse.json({ error: 'Image must be a non-empty string' }, { status: 400 })
+    }
+
+    // Validate base64 string length (~5MB limit)
+    const MAX_BASE64_LENGTH = 7_000_000
+    if (image.length > MAX_BASE64_LENGTH) {
+      return NextResponse.json(
+        { error: `Image exceeds maximum size (${MAX_BASE64_LENGTH} characters)` },
+        { status: 400 },
+      )
+    }
+
+    // Validate MIME type against allowlist
+    const ALLOWED_MIME_TYPES = ['image/jpeg', 'image/png', 'image/webp', 'image/gif']
+    if (!ALLOWED_MIME_TYPES.includes(mimeType)) {
+      return NextResponse.json(
+        { error: `Unsupported MIME type. Allowed: ${ALLOWED_MIME_TYPES.join(', ')}` },
+        { status: 400 },
+      )
+    }
+
     const genAI = getGeminiClient()
     const model = genAI.getGenerativeModel({
       model: 'gemini-3.1-flash-lite-preview',


### PR DESCRIPTION
## Summary
- Adds max base64 size check (7M chars / ~5MB) to `/api/analyze`
- Validates MIME type against allowlist (`image/jpeg`, `image/png`, `image/webp`, `image/gif`)
- Validates image is a non-empty string
- Returns 400 with descriptive errors for all invalid inputs

Closes #3

## Test plan
- [ ] POST with oversized base64 string → 400 with size error
- [ ] POST with `mimeType: "text/plain"` → 400 with MIME error
- [ ] POST with valid JPEG → analysis proceeds normally
- [ ] POST with empty image string → 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)