### PR TITLE
fix(reliability): add schema validation for Gemini API response

### DIFF
--- a/app/api/analyze/route.ts
+++ b/app/api/analyze/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getGeminiClient, SYSTEM_PROMPT } from '@/lib/gemini'
+import { validateAnalysisResponse } from '@/lib/validate'
 
 export const maxDuration = 60
 
@@ -33,7 +34,15 @@ export async function POST(req: NextRequest) {
     const clean = text.replace(/^```(?:json)?\n?/, '').replace(/\n?```$/, '').trim()
     const parsed = JSON.parse(clean)
 
-    return NextResponse.json(parsed)
+    const result2 = validateAnalysisResponse(parsed)
+    if (!result2.valid) {
+      return NextResponse.json(
+        { error: `Invalid AI response: ${result2.error}` },
+        { status: 502 },
+      )
+    }
+
+    return NextResponse.json(result2.data)
   } catch (err: unknown) {
     console.error('[analyze]', err)
     const message = err instanceof Error ? err.message : 'Analysis failed'

--- a/lib/validate.ts
+++ b/lib/validate.ts
@@ -1,0 +1,73 @@
+const ALLOWED_CONFIDENCE = ['Very High', 'High', 'Medium', 'Low', 'Very Low'] as const
+
+export type ValidationResult =
+  | { valid: true; data: { locations: unknown[] } }
+  | { valid: false; error: string }
+
+export function validateAnalysisResponse(parsed: unknown): ValidationResult {
+  if (parsed === null || typeof parsed !== 'object') {
+    return { valid: false, error: 'Response is not an object' }
+  }
+
+  const obj = parsed as Record<string, unknown>
+
+  if (!Array.isArray(obj.locations)) {
+    return { valid: false, error: 'Response missing "locations" array' }
+  }
+
+  if (obj.locations.length !== 3) {
+    return { valid: false, error: `Expected 3 locations, got ${obj.locations.length}` }
+  }
+
+  for (let i = 0; i < obj.locations.length; i++) {
+    const loc = obj.locations[i] as Record<string, unknown>
+    const prefix = `locations[${i}]`
+
+    if (loc === null || typeof loc !== 'object') {
+      return { valid: false, error: `${prefix} is not an object` }
+    }
+
+    if (typeof loc.location !== 'string' || loc.location.length === 0) {
+      return { valid: false, error: `${prefix}.location must be a non-empty string` }
+    }
+
+    if (
+      typeof loc.confidence !== 'string' ||
+      !(ALLOWED_CONFIDENCE as readonly string[]).includes(loc.confidence)
+    ) {
+      return {
+        valid: false,
+        error: `${prefix}.confidence must be one of: ${ALLOWED_CONFIDENCE.join(', ')}`,
+      }
+    }
+
+    if (loc.clues === null || typeof loc.clues !== 'object') {
+      return { valid: false, error: `${prefix}.clues must be an object` }
+    }
+
+    const clues = loc.clues as Record<string, unknown>
+
+    if (!Array.isArray(clues.numbered)) {
+      return { valid: false, error: `${prefix}.clues.numbered must be an array` }
+    }
+
+    if (clues.numbered.length < 2 || clues.numbered.length > 4) {
+      return {
+        valid: false,
+        error: `${prefix}.clues.numbered must have 2-4 items, got ${clues.numbered.length}`,
+      }
+    }
+
+    for (let j = 0; j < clues.numbered.length; j++) {
+      if (typeof clues.numbered[j] !== 'string') {
+        return { valid: false, error: `${prefix}.clues.numbered[${j}] must be a string` }
+      }
+    }
+
+    if (typeof clues.summary !== 'string' || clues.summary.length === 0) {
+      return { valid: false, error: `${prefix}.clues.summary must be a non-empty string` }
+    }
+  }
+
+  return { valid: true, data: obj as { locations: unknown[] } }
+}


### PR DESCRIPTION
## Summary
- Adds `lib/validate.ts` with zero-dependency response validation
- Validates: locations array (exactly 3), each with location, confidence enum, clues object
- Returns 502 Bad Gateway when Gemini returns unexpected structure
- Descriptive error messages pinpoint which field failed

Closes #10

## Test plan
- [ ] Valid Gemini response → passes through unchanged
- [ ] Missing `locations` → 502 with descriptive error
- [ ] Wrong number of locations → 502 with count error
- [ ] Invalid confidence value → 502 with enum error
- [ ] Normal end-to-end analysis still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)