### PR TITLE
feat(ui): add upload guidance text for best results

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -113,6 +113,10 @@ export default function HomePage() {
           disabled={isLoading}
         />
 
+        <p className="text-xs text-muted-foreground text-center">
+          Best results with outdoor photos showing buildings, street signs, landscapes, or infrastructure.
+        </p>
+
         {/* Error */}
         {error && (
           <div className="rounded-lg bg-destructive/10 border border-destructive/20 px-4 py-3 text-sm text-destructive">


### PR DESCRIPTION
## Summary
- Adds one line of muted guidance text below the photo upload area
- "Best results with outdoor photos showing buildings, street signs, landscapes, or infrastructure."
- Non-intrusive styling: `text-xs text-muted-foreground text-center`

Closes #15

## Test plan
- [ ] Text visible on home page below upload area
- [ ] Readable in both light and dark mode
- [ ] Does not interfere with upload interaction
- [ ] Mobile layout correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)